### PR TITLE
Document remote service fields for activities

### DIFF
--- a/sections/activities.md
+++ b/sections/activities.md
@@ -94,6 +94,9 @@ Mandatory fields are marked with a star (*):
 * **hours*** – 1.0
 * **billable** – true/false (default: `true` or dependent on project configuration)
 * **tag** – "RMT-123" (any tag as a string)
+* **remote_service** – jira (Allowed values are: "trello", "jira", "asana", "basecamp", "wunderlist", "basecamp2", "basecamp3", "toggl", "mite")
+* **remote_id** – PRJ-2342
+* **remote_url** – https://jira.meinefirma.de/browse/PRJ-2342
 
 ## PUT /activities/{id}
 


### PR DESCRIPTION
* Properly document remote service fields (`remote_id`, `remote_service`, `remote_url`)
* Add `mite` to the remote service list