### PR TITLE
Fix relative link

### DIFF
--- a/sections/schedules.md
+++ b/sections/schedules.md
@@ -4,7 +4,7 @@ German: "Absenz"
 
 ## Attributes
 
-Schedules are now used for absences only. Use [Planning Entries](sections/planning_entries.md) for project schedules.
+Schedules are now used for absences only. Use [Planning Entries](planning_entries.md) for project schedules.
 
 The schedule representation contains among the standard fields also:
 


### PR DESCRIPTION
The resulting link was pointing to `/sections/sections/planning_entries.md` as it is relative and we are already in the `sections` directory. This change removes this extra `sections`.

[Broken version](https://github.com/hundertzehn/mocoapp-api-docs/blob/36b5698eae0720c46a6fc68ea70aa344855cab36/sections/schedules.md)