### PR TITLE
fix: renames user.external into user.extern

### DIFF
--- a/sections/users.md
+++ b/sections/users.md
@@ -10,7 +10,7 @@ German: "Personal"
   "firstname": "Max",
   "lastname": "Muster",
   "active": true,
-  "external": false,
+  "extern": false,
   "email": "max.muster@beispiel.de",
   "mobile_phone": "+49 177 123 45 67",
   "work_phone": "+49 40 123 45 67",


### PR DESCRIPTION
In your documentation [in the section of the user entity's attributes](https://github.com/hundertzehn/mocoapp-api-docs/blob/master/sections/users.md#attributes) you mention the attribute `external`. This does not match the actual return of the API which names this attribute `extern`.

Documentation:
```json
{
  ...
  "external": false,
  ...
}
```

Actual API response:
```json
{
  ...
  "extern": false,
  ...
}
```